### PR TITLE
Use monospace font for input text

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -53,6 +53,7 @@ mark::after {
 }
 
 input[name='q'] {
+  font-family: monospace;
   font-size: 1.25em;
 
   display: block;


### PR DESCRIPTION
Unlike https://doc.sherlocode.com/, currently https://sherlocode.com/ uses default font family for input text (or called search query).

I find the dash `-` in non-monospace font less readable.

- [doc.sherlocode.com](https://doc.sherlocode.com/?q=%3A%20%27a%20*%20%27b%20-%3E%20%27b)
  ![image](https://github.com/user-attachments/assets/fbeb2a3f-397e-4749-9c0f-4b59d9a1a283)
- [sherlocode.com](https://sherlocode.com/?q=%3A%20%27a%20*%20%27b%20-%3E%20%27b)
  ![image](https://github.com/user-attachments/assets/26cfd9a9-6716-4da9-a727-2b3d65ad2c49)

